### PR TITLE
Use association about /rooms/xxx/members

### DIFF
--- a/lib/chatwork/room.rb
+++ b/lib/chatwork/room.rb
@@ -23,7 +23,7 @@ module Chatwork
     ICON_SPORTS = 'sports'.freeze
     ICON_TRAVEL = 'travel'.freeze
 
-    has_many :members, :class_name => 'chatwork/member'
+    has_many :members, class_name: 'chatwork/member'
 
     self.collection_name = 'rooms'
     self.primary_key = 'room_id'

--- a/lib/chatwork/room.rb
+++ b/lib/chatwork/room.rb
@@ -23,6 +23,8 @@ module Chatwork
     ICON_SPORTS = 'sports'.freeze
     ICON_TRAVEL = 'travel'.freeze
 
+    has_many :members, :class_name => 'chatwork/member'
+
     self.collection_name = 'rooms'
     self.primary_key = 'room_id'
 
@@ -32,10 +34,6 @@ module Chatwork
 
     def message(pk)
       Message.find(pk, params: subroute_params)
-    end
-
-    def members(params = {})
-      Member.all(params: subroute_params(params))
     end
 
     def update_members(params = {})

--- a/lib/chatwork/version.rb
+++ b/lib/chatwork/version.rb
@@ -1,3 +1,3 @@
 module Chatwork
-  VERSION = '1.0.0'.freeze
+  VERSION = '1.0.1'.freeze
 end


### PR DESCRIPTION
`/rooms/xxx/members` can use associations.
But other relationship (ex. `/rooms/xxx/messages`) cannot use associations because it uses query parameters.

So I use association /rooms/xxx/members only
